### PR TITLE
added ingressClassName: nginx under spec in Day 05 Ingress.yml

### DIFF
--- a/Day 05 IngressController-TLS-RegistrySecret-Probes/Ingress.yml
+++ b/Day 05 IngressController-TLS-RegistrySecret-Probes/Ingress.yml
@@ -7,6 +7,7 @@ metadata:
     spec.ingressClassName: nginx
 #  changed - as it is depracted "kubernetes.io/ingress.class"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - "result.cloudvishwakarma.in"
@@ -33,6 +34,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     spec.ingressClassName: nginx
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - "vote.cloudvishwakarma.in"


### PR DESCRIPTION
Hi Sai,
  I was getting 404 Not found error when I deployed the Ingress resource (ingress.yaml). I added this  ingressClassName: nginx under spec and it worked .
  
Below is the link to the stack overflow page I referred to: 
https://stackoverflow.com/questions/69774596/ingress-not-binding-to-load-balancer

please review 

Thanks,
Medha 
